### PR TITLE
count nodejs as javascript

### DIFF
--- a/crawl.py
+++ b/crawl.py
@@ -49,7 +49,7 @@ languages = [
     ('haskell', ['haskell']),
     ('haxe', ['haxe']),
     ('java', ['java']),
-    ('javascript', ['javascript']), # 'js'
+    ('javascript', ['javascript', 'nodejs']), # 'js'
     ('lisp', ['lisp']),
     ('lua', ['lua']),
     ('mathematica', ['mathematica']),


### PR DESCRIPTION
It's quite common to refer to javascript running on nodejs as such or simply "node" but that might give way to many false positives
